### PR TITLE
fix for relative lookups

### DIFF
--- a/lib/builders/scripts.js
+++ b/lib/builders/scripts.js
@@ -235,7 +235,7 @@ Scripts.prototype.define = function (file) {
  */
 
 Scripts.prototype.lookup = function (file, target) {
-  return target.slice(0, 2) === './'
+  return target.slice(0, 2) === './' || target.slice(0, 3) === '../'
     ? this.lookupRelative(file, target)
     : this.lookupDependency(file, target);
 }


### PR DESCRIPTION
resolve of paths like:

``` javascript
var utils = require("../utils");
```
