### PR TITLE
Convert relative file's path to lowercase when looking for relative

### DIFF
--- a/lib/builders/scripts.js
+++ b/lib/builders/scripts.js
@@ -279,10 +279,10 @@ Scripts.prototype.lookupRelative = function (file, target) {
     var f = files[i];
     for (var j = 0; j < extensions.length; j++) {
       // check by adding extensions
-      if (f.path === path + extensions[j]) return f.name;
+      if (f.path.toLowerCase() === path + extensions[j]) return f.name;
     }
     // check by removing extensions
-    if (f.path.replace(/\.\w+$/, '') === path) return f.name;
+    if (f.path.replace(/\.\w+$/, '').toLowerCase() === path) return f.name;
   }
 
   var message = 'could not resolve "' + target + '" from "' + file.branch.name + '"\'s file "' + file.path + '"';

--- a/test/fixtures/js-relative-camelcase/component.json
+++ b/test/fixtures/js-relative-camelcase/component.json
@@ -1,0 +1,7 @@
+{
+  "name": "js-relative-camelcase",
+  "scripts": [
+    "index.js",
+    "src/somethingCamelCase.js"
+  ]
+}

--- a/test/fixtures/js-relative-camelcase/index.js
+++ b/test/fixtures/js-relative-camelcase/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/somethingCamelCase');

--- a/test/fixtures/js-relative-camelcase/src/somethingCamelCase.js
+++ b/test/fixtures/js-relative-camelcase/src/somethingCamelCase.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -258,6 +258,29 @@ describe('js-relative-up', function () {
   })
 })
 
+describe('js-relative-camelcase', function () {
+  var tree
+  var js = Builder.require
+
+  it('should install', co(function* () {
+    tree = yield* resolve(fixture('js-relative-camelcase'), options)
+  }))
+
+  it('should build', co(function* () {
+    js += yield build(tree).end();
+  }))
+
+  it('should rewrite requires', function  () {
+    js.should.not.include("require('../')")
+  })
+
+  it('should execute', function () {
+    var ctx = vm.createContext()
+    vm.runInContext(js, ctx)
+    vm.runInContext('if (require("js-relative-camelcase") !== 1) throw new Error()', ctx)
+  })
+})
+
 describe('js-multiple-names', function () {
   var tree;
   var js = Builder.require;


### PR DESCRIPTION
Not sure this should be done in `builder2` or in `manifest.js`, but to demonstrate the bug.

Also to avoid repeating `toLowerCase` we can possibly re-write them to something like:

``` javascript
  for (var i = 0; i < files.length; i++) {
    var f = files[i];
    var p = f.path.toLowerCase();
    for (var j = 0; j < extensions.length; j++) {
      // check by adding extensions
      if (p === path + extensions[j]) return f.name;
    }
    // check by removing extensions
    if (p.replace(/\.\w+$/, '') === path) return f.name;
  }
```
