### PR TITLE
fix js-page.js test 

### DIFF
--- a/test/scripts.js
+++ b/test/scripts.js
@@ -421,6 +421,7 @@ describe('js-page.js', function () {
   it('should execute', function () {
     var ctx = vm.createContext();
     vm.runInContext(js, ctx);
+    vm.runInContext('require("js-page.js")', ctx);
   })
 })
 


### PR DESCRIPTION
I think this test is failing
We forgot to "auto require" the package in the 'js-page.js' test
The feature is actually broken, the test is failing now..
you can't require a package that have a (json package) name that does not match package name
