### PR TITLE
Updating css-url-rewriter

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,19 +11,19 @@
   "license": "MIT",
   "repository": "component/builder2.js",
   "dependencies": {
-    "debug": "*",
-    "generator-supported": "~0.0.1",
+    "chanel": "^2.0.0",
+    "co": "^3.0.2",
     "component-flatten": "^1.0.0",
     "component-manifest": "^1.0.0",
     "component-require2": "^1.0.0",
-    "css-url-rewriter": "~0.0.1",
-    "syntax-error": "^1.1.1",
-    "requires": "^1.0.0",
+    "cp": "~0.1.1",
+    "css-url-rewriter": "^0.1.0",
+    "debug": "*",
+    "generator-supported": "~0.0.1",
     "graceful-fs": "^2.0.1",
     "mkdirp": "~0.3.5",
-    "cp": "~0.1.1",
-    "chanel": "^2.0.0",
-    "co": "^3.0.2"
+    "requires": "^1.0.0",
+    "syntax-error": "^1.1.1"
   },
   "devDependencies": {
     "component-resolver": "^1.0.0",


### PR DESCRIPTION
I was having a build issue with CSS urls not being rewritten properly. It turns out that the `css-url-rewriter` improved in `v0.1.0` and I figured it would be reasonable to update this here. (sorry, `npm --save` reordered the dependencies list)
