### PR TITLE
don't throw errors for server side require`s

### DIFF
--- a/lib/builders/scripts.js
+++ b/lib/builders/scripts.js
@@ -196,9 +196,10 @@ Scripts.prototype.register = function (file) {
 
   // rewrite all the requires
   js = requires(js, function (require) {
-    return 'require("'
+    var quote = require.string.match(/"/) ? '"' : "'";
+    return 'require(' + quote
       + self.lookup(file, require.path)
-      + '")';
+      + quote + ')';
   });
 
   var name = file.name;
@@ -224,7 +225,6 @@ Scripts.prototype.register = function (file) {
       + js
       + '\n});';
   }
-
   return js;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "component-builder",
+  "name": "component-builder-fix",
   "description": "builder for component",
-  "version": "1.1.6",
+  "version": "1.1.8-fix",
   "author": {
     "name": "Jonathan Ong",
     "email": "me@jongleberry.com",


### PR DESCRIPTION
allow environment check also for locals
for instance:

``` js
if (typeof window === 'undefined') {
  require('../local-component');
} else {
  require('local-component')
}
```
