### PR TITLE
allow using fragment identifier in css url.

### DIFF
--- a/lib/plugins/url-rewriter.js
+++ b/lib/plugins/url-rewriter.js
@@ -26,6 +26,7 @@ module.exports = function (prefix, options) {
       file.string = rewriteCSSURLs(string, function (uri) {
         if (isData(uri)) return uri;
         if (isAbsolute(uri)) return uri;
+        if (isFragment(uri)) return uri;
         uri = resolve(file.path, uri);
         uri = resolve(prefix + utils.rewriteUrl(branch) + '/', uri);
         return uri;
@@ -59,4 +60,16 @@ module.exports = function (prefix, options) {
 function isAbsolute(url) {
   return ~url.indexOf('://')
     || '/' === url[0];
+}
+
+/**
+ * Check if a URL is just a Fragment identifier.
+ *
+ * @param {String} url
+ * @return {Boolean}
+ * @api public
+ */
+
+function isFragment(url) {
+  return !url.indexOf('#');
 }


### PR DESCRIPTION
this target the case of SVG properties in CSS.
example:

``` css
.elm {
  mask: url(#localstyle);
}
```

since the URL contains only a hash tag, this means that the URL references an element in the document. so URL rewrite is not supposed to alter it.
