### PR TITLE
Use canonical name as ID for AMD define()

### DIFF
--- a/lib/builders/scripts.js
+++ b/lib/builders/scripts.js
@@ -73,7 +73,7 @@ Scripts.umd = function (canonical, alias, js) {
     + 'if (typeof exports == "object") {\n'
     + '  module.exports = require("' + canonical + '");\n'
     + '} else if (typeof define == "function" && define.amd) {\n'
-    +'  define([], function(){ return require("' + canonical + '"); });\n'
+    +'  define("' + canonical + '", [], function(){ return require("' + canonical + '"); });\n'
     + '} else {\n'
     + '  this["' + alias + '"] = require("' + canonical + '");\n'
     + '}\n'


### PR DESCRIPTION
This PR updates the UMD boilerplate to provide an ID argument to the AMD `define` function, per [this specification](https://github.com/amdjs/amdjs-api/wiki/AMD#define-function-).

This change is in the interest of making the `--standalone` function of `component-build` actually produce a component which can be used in a standalone manner—that is to say, a component that is identified by its name with the AMD loader.
