### PR TITLE
Exports: this is undefined with "use strict"

### DIFF
--- a/lib/builders/scripts.js
+++ b/lib/builders/scripts.js
@@ -75,7 +75,7 @@ Scripts.umd = function (canonical, alias, js) {
     + '} else if (typeof define == "function" && define.amd) {\n'
     +'  define([], function(){ return require("' + canonical + '"); });\n'
     + '} else {\n'
-    + '  this["' + alias + '"] = require("' + canonical + '");\n'
+    + '  (this || window)["' + alias + '"] = require("' + canonical + '");\n'
     + '}\n'
     + '})()\n';
 }


### PR DESCRIPTION
When "use strict" is set, then `this` would be undefined. This can happen, e.g., if the component is embedded into some single file with the global "use strict".
